### PR TITLE
Credential Offer 2.0 based on the Credential Manifest Spec

### DIFF
--- a/lib/credential.ts
+++ b/lib/credential.ts
@@ -1,5 +1,6 @@
 import { ClaimInterface } from 'cred-types-jolocom-core'
 import { JsonLdObject } from './linkedData'
+import { CredentialOfferInputRequest, CredentialOfferRenderInfo, CredentialOfferMetadata } from "./interactionTokens"
 
 type ClaimType = string | number | boolean | {}
 /**
@@ -28,4 +29,87 @@ export interface ICredentialAttrs extends JsonLdObject {
   type: string[]
   name?: string
   claim: ClaimEntry
+}
+
+/**
+ * This is here for backwards compatibility
+ * @deprecated
+ */
+export interface CredentialOffer1 {
+  type: string
+  // NOTE: DEPRECATED FIXME remove @next
+  // They were all optional and client apps (i.e. SmartWallet) didn't care about
+  // them too much
+  requestedInput?: CredentialOfferInputRequest
+  renderInfo?: CredentialOfferRenderInfo
+  metadata?: CredentialOfferMetadata
+}
+
+/**
+ * CredentialOffer2 is based on the Credential Manifest Spec: https://identity.foundation/credential-manifest/
+ */
+export interface CredentialOffer2 {
+  type: string
+  locale?: string
+  issuer?: IssuerManifest
+  credential?: CredentialDefinition
+  // TODO
+  // presentation_definition?: PresentationDefinition
+}
+
+/**
+ * This interface extends both verysion for backwards compatibility
+ */
+export interface CredentialOffer extends CredentialOffer2, CredentialOffer1 { }
+
+export interface IssuerManifest {
+  id: string
+  name?: string
+  styles?: {
+    thumbnail?: CredentialDefinitionImage
+    hero?: CredentialDefinitionImage
+    background?: {
+      color?: string
+    }
+    text?: {
+      color?: string
+    }
+  }
+}
+
+export interface CredentialDefinition {
+  schema: string
+  name?: string
+  description?: string
+  display?: {
+    title?: CredentialManifestDisplayMapping
+    subtitle?: CredentialManifestDisplayMapping
+    description?: CredentialManifestDisplayMapping
+    properties?: CredentialManifestDisplayMapping[]
+  }
+  styles?: {
+    thumbnail?: CredentialDefinitionImage
+    hero?: CredentialDefinitionImage
+    background?: {
+      color?: string
+    }
+    text?: {
+      color?: string
+    }
+
+  }
+}
+
+// TODO
+// interface PresentationDefinition { }
+
+export interface CredentialManifestDisplayMapping {
+  path?: string[]
+  text?: string
+  label?: string
+}
+
+export interface CredentialDefinitionImage {
+  uri: string
+  alt: string
 }

--- a/lib/credential.ts
+++ b/lib/credential.ts
@@ -1,6 +1,5 @@
 import { ClaimInterface } from 'cred-types-jolocom-core'
 import { JsonLdObject } from './linkedData'
-import { CredentialOfferInputRequest, CredentialOfferRenderInfo, CredentialOfferMetadata } from "./interactionTokens"
 
 type ClaimType = string | number | boolean | {}
 /**
@@ -30,6 +29,35 @@ export interface ICredentialAttrs extends JsonLdObject {
   name?: string
   claim: ClaimEntry
 }
+
+export interface CredentialOfferInputRequest {
+  [key: string]: string | null
+}
+
+export enum CredentialRenderTypes {
+  document = 'document',
+  permission = 'permission',
+  claim = 'claim',
+}
+
+export interface CredentialOfferRenderInfo {
+  renderAs?: CredentialRenderTypes
+  background?: {
+    color?: string // Hex value
+    url?: string // URL to base64 encoded background image
+  }
+  logo?: {
+    url: string // URL to base64 encoded image
+  }
+  text?: {
+    color: string // Hex value
+  }
+}
+
+export interface CredentialOfferMetadata {
+  asynchronous?: boolean
+}
+
 
 /**
  * This is here for backwards compatibility

--- a/lib/didDocument.ts
+++ b/lib/didDocument.ts
@@ -1,0 +1,35 @@
+import { ILinkedDataSignatureAttrs } from './linkedDataSignature'
+import { ContextEntry, JsonLdObject } from '../'
+
+export interface IDidDocumentAttrs {
+  '@context': ContextEntry[] | string
+  specVersion?: number
+  id: string
+  authentication?:
+    | IAuthenticationSectionAttrsv0[]
+    | IAuthenticationSectionAttrs[]
+  publicKey?: IPublicKeySectionAttrs[]
+  service?: IServiceEndpointSectionAttrs[]
+  created?: string
+  proof?: ILinkedDataSignatureAttrs
+}
+
+export interface IPublicKeySectionAttrs extends JsonLdObject {
+  id: string
+  type: string
+  publicKeyHex: string
+}
+
+export interface IServiceEndpointSectionAttrs extends JsonLdObject {
+  id: string
+  type: string
+  serviceEndpoint: string
+  description: string
+}
+
+export interface IAuthenticationSectionAttrsv0 {
+  publicKey: string
+  type: string
+}
+
+export type IAuthenticationSectionAttrs = IPublicKeySectionAttrs | string

--- a/lib/interactionTokens.ts
+++ b/lib/interactionTokens.ts
@@ -45,36 +45,8 @@ export interface IPaymentResponseAttrs {
   txHash: string
 }
 
-export enum CredentialRenderTypes {
-  document = 'document',
-  permission = 'permission',
-  claim = 'claim',
-}
-
-export interface CredentialOfferInputRequest {
-  [key: string]: string | null
-}
-
-export interface CredentialOfferRenderInfo {
-  renderAs?: CredentialRenderTypes
-  background?: {
-    color?: string // Hex value
-    url?: string // URL to base64 encoded background image
-  }
-  logo?: {
-    url: string // URL to base64 encoded image
-  }
-  text?: {
-    color: string // Hex value
-  }
-}
-
-export interface CredentialOfferMetadata {
-  asynchronous?: boolean
-}
-
 // TODO @next this is here for backwards compatibility
-export { CredentialOffer } from './credential'
+export { CredentialOffer, CredentialOfferInputRequest, CredentialOfferRenderInfo, CredentialOfferMetadata } from "./credential"
 
 export interface CredentialOfferRequestAttrs {
   callbackURL: string

--- a/lib/interactionTokens.ts
+++ b/lib/interactionTokens.ts
@@ -33,6 +33,7 @@ export interface IInteractionToken {
 
 import { TransactionOptions } from './contracts'
 import { ISignedCredentialAttrs } from './signedCredential'
+import { CredentialOffer } from './credential'
 
 export interface IPaymentRequestAttrs {
   callbackURL: string
@@ -72,12 +73,8 @@ export interface CredentialOfferMetadata {
   asynchronous?: boolean
 }
 
-export interface CredentialOffer {
-  type: string
-  requestedInput?: CredentialOfferInputRequest
-  renderInfo?: CredentialOfferRenderInfo
-  metadata?: CredentialOfferMetadata
-}
+// TODO @next this is here for backwards compatibility
+export { CredentialOffer } from './credential'
 
 export interface CredentialOfferRequestAttrs {
   callbackURL: string


### PR DESCRIPTION
Based on https://identity.foundation/credential-manifest/ a new `CredentialOffer` type is defined, keeping backwards compatibility with the older version for now. Related [notion card](https://www.notion.so/jolocom/CredentialOffer-2-0-d0c132e675614b3698dc87c2cf900768)